### PR TITLE
Handle multiple languages for an extension

### DIFF
--- a/src/languages.ts
+++ b/src/languages.ts
@@ -35,11 +35,32 @@ export class Languages {
   private loadExtensionMap = () => {
     const extensions: ExtensionsTypes = {};
 
+    /**
+     * The extension map can contain multiple languages with the same extension,
+     * but we only want a single one. For the moment, these clashes are resolved
+     * by the simple heuristic below listing high-priority languages. We may want
+     * to consider smarter heuristics to correctly identify languages in cases
+     * where the extension is ambiguous. The ordering of the list matters and
+     * languages earlier on will get a higher priority when resolving clashes.
+     */
+    const importantLanguages = ["javascript", "typescript", "ruby", "python", "java", "c", "c++", "c#", "rust", "scala", "perl", "go"];
+
     Object.keys(languageMap).forEach((language) => {
       const languageMode = languageMap[language];
       const languageExtensions = (languageMode && languageMode.extensions) || [];
       languageExtensions.forEach((extension: string) => {
-        extensions[extension.toLowerCase()] = language.toLowerCase();
+        if (!extensions[extension.toLowerCase()]) {
+          extensions[extension.toLowerCase()] = language.toLowerCase();
+        } else {
+          const currentLanguagePriority = importantLanguages.indexOf(extensions[extension.toLowerCase()]);
+          if (currentLanguagePriority == -1) {
+            extensions[extension.toLowerCase()] = language.toLowerCase();
+          } else {
+            const otherPriority = importantLanguages.indexOf(language.toLowerCase());
+            if (otherPriority != -1 && otherPriority < currentLanguagePriority)
+              extensions[extension.toLowerCase()] = language.toLowerCase();
+          }
+        }
       });
     });
 

--- a/src/languages.ts
+++ b/src/languages.ts
@@ -12,6 +12,17 @@ interface ExtensionsTypes {
 export interface DetectorOptions {}
 
 /**
+ * The extension map can contain multiple languages with the same extension,
+ * but we only want a single one. For the moment, these clashes are resolved
+ * by the simple heuristic below listing high-priority languages. We may want
+ * to consider smarter heuristics to correctly identify languages in cases
+ * where the extension is ambiguous. The ordering of the list matters and
+ * languages earlier on will get a higher priority when resolving clashes.
+ */
+const importantLanguages = ["javascript", "typescript", "ruby", "python", "java", "c", "c++", "c#", "rust", "scala", "perl", "go"];
+
+
+/**
  * detecte program language through file extension
  *
  * @export
@@ -35,30 +46,22 @@ export class Languages {
   private loadExtensionMap = () => {
     const extensions: ExtensionsTypes = {};
 
-    /**
-     * The extension map can contain multiple languages with the same extension,
-     * but we only want a single one. For the moment, these clashes are resolved
-     * by the simple heuristic below listing high-priority languages. We may want
-     * to consider smarter heuristics to correctly identify languages in cases
-     * where the extension is ambiguous. The ordering of the list matters and
-     * languages earlier on will get a higher priority when resolving clashes.
-     */
-    const importantLanguages = ["javascript", "typescript", "ruby", "python", "java", "c", "c++", "c#", "rust", "scala", "perl", "go"];
-
     Object.keys(languageMap).forEach((language) => {
       const languageMode = languageMap[language];
       const languageExtensions = (languageMode && languageMode.extensions) || [];
       languageExtensions.forEach((extension: string) => {
-        if (!extensions[extension.toLowerCase()]) {
-          extensions[extension.toLowerCase()] = language.toLowerCase();
+        const lowerCaseExtension = extension.toLowerCase();
+        const lowerCaseLanguage = language.toLowerCase()
+        if (!extensions[lowerCaseExtension]) {
+          extensions[lowerCaseExtension] = lowerCaseLanguage;
         } else {
-          const currentLanguagePriority = importantLanguages.indexOf(extensions[extension.toLowerCase()]);
-          if (currentLanguagePriority == -1) {
-            extensions[extension.toLowerCase()] = language.toLowerCase();
+          const currentLanguagePriority = importantLanguages.indexOf(extensions[lowerCaseExtension]);
+          if (currentLanguagePriority === -1) {
+            extensions[lowerCaseExtension] = lowerCaseLanguage;
           } else {
-            const otherPriority = importantLanguages.indexOf(language.toLowerCase());
-            if (otherPriority != -1 && otherPriority < currentLanguagePriority)
-              extensions[extension.toLowerCase()] = language.toLowerCase();
+            const otherPriority = importantLanguages.indexOf(lowerCaseLanguage);
+            if (otherPriority !== -1 && otherPriority < currentLanguagePriority)
+              extensions[lowerCaseExtension] = lowerCaseLanguage;
           }
         }
       });

--- a/test/data2/x.cs
+++ b/test/data2/x.cs
@@ -1,0 +1,16 @@
+using System;
+
+// A comment
+/*
+ * A multi-line comment
+ */
+namespace HelloWorldApp {
+    class Geeks {
+        static void Main(string[] args) {
+            if (true) {
+                Console.WriteLine("Hello World!");
+            }
+        }
+    }
+}
+

--- a/test/directory.test.ts
+++ b/test/directory.test.ts
@@ -9,17 +9,24 @@ describe('Directory', () => {
       cwd: __dirname + '/data2'
     }, {
       files: [
+        'data2/x.cs',
         'data2/x.html',
         'data2/x.js',
         'data2/x.py',
         'data2/x.rb',
       ],
       info: {
-        code: 23,
-        comment: 23,
-        total: 61,
+        code: 33,
+        comment: 27,
+        total: 78,
       },
       languages: {
+        "c#": {
+          code: 10,
+          comment: 4,
+          sum: 1,
+          total: 17,
+        },
         html: {
           code: 4,
           comment: 4,

--- a/test/file.test.ts
+++ b/test/file.test.ts
@@ -56,6 +56,19 @@ describe('File', () => {
     });
   });
 
+  it('should calculate info for a csharp file', async () => {
+    await doTest('x.cs', {
+      languages: 'c#',
+      lines: {
+        code: 10,
+        comment: 4,
+        total: 17
+      },
+      name: 'x.cs',
+      size: 253
+    });
+  });
+
   async function doTest(fileName: string, expectedFileInfo: FileInfo) {
     const fullPath = slash(path.join(__dirname, `/data2/${fileName}`));
     const actualFileInfo = await new LocFile(fullPath).getFileInfo();


### PR DESCRIPTION
Addresses the underlying cause of https://github.com/github/codeql-action/issues/584, though will not close it yet as we still have to bump the version of this that the CodeQL Action depends on and add a test there to avoid a regression.

The language map that we import unfortunately has some ambiguity in what language an extension maps to since some programming languages where extensions. Currently, we just use whatever appears later in the alphabet, which results in (for example), Smalltalk overriding C# which is clearly not desirable. This PR adds a simple heuristic of languages that are important enough to take priority over other ones. The list is roughly based on a list of most popular programming languages in order of popularity, with some manual adjustments to resolve clashes that in my opinion ended up being resolved the wrong way by doing this. For example, I moved Ruby quite high up because `.spec` appears a lot in Ruby tests but is also an extension in Python where it used much less.